### PR TITLE
Tried to convert this to python3 code which is compatible to python2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *~
 *.pyc
 .#*
+/.project

--- a/xdo/__init__.py
+++ b/xdo/__init__.py
@@ -15,7 +15,7 @@ from .xdo import (SEARCH_TITLE, SEARCH_CLASS, SEARCH_NAME, SEARCH_PID,  # noqa
 from .xdo import XdoException  # noqa
 
 if sys.version_info < (3,):
-        range = xrange
+    range = xrange
 
 mouse_location = namedtuple('mouse_location', 'x,y,screen_num')
 mouse_location2 = namedtuple('mouse_location2', 'x,y,screen_num,window')

--- a/xdo/__init__.py
+++ b/xdo/__init__.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import ctypes
 from ctypes import POINTER
 from collections import namedtuple
@@ -13,6 +14,8 @@ from .xdo import (SEARCH_TITLE, SEARCH_CLASS, SEARCH_NAME, SEARCH_PID,  # noqa
                   SEARCH_DESKTOP)
 from .xdo import XdoException  # noqa
 
+if sys.version_info < (3,):
+        range = xrange
 
 mouse_location = namedtuple('mouse_location', 'x,y,screen_num')
 mouse_location2 = namedtuple('mouse_location2', 'x,y,screen_num,window')
@@ -714,7 +717,7 @@ class Xdo(object):
             ctypes.byref(windowlist_ret),
             ctypes.byref(nwindows_ret))
 
-        return [windowlist_ret[i] for i in xrange(nwindows_ret.value)]
+        return [windowlist_ret[i] for i in range(nwindows_ret.value)]
 
     def get_window_property_by_atom(self, window, atom):
         # todo: figure out what exactly this method does, and implement it
@@ -733,7 +736,7 @@ class Xdo(object):
 
         # todo: we need to convert atoms into their actual type..
         values = []
-        for i in xrange(nitems):
+        for i in range(nitems):
             i_val = value[i]
             # i_type = type_[i]
             values.append(i_val)
@@ -789,7 +792,7 @@ class Xdo(object):
 
         _libxdo.xdo_get_active_modifiers(
             self._xdo, ctypes.byref(keys), ctypes.byref(nkeys))
-        return [keys[i] for i in xrange(nkeys.value)]
+        return [keys[i] for i in range(nkeys.value)]
 
     def clear_active_modifiers(self, window, mods=None):
         """

--- a/xdo/xdo.py
+++ b/xdo/xdo.py
@@ -2,9 +2,13 @@
 Ctypes bindings for libxdo
 """
 
+import sys
 import ctypes
 from ctypes import (Structure, POINTER, c_int, c_char, c_char_p, c_wchar,
                     c_void_p, c_long, c_uint, c_ulong, c_bool)
+
+if sys.version_info < (3,):
+        range = xrange
 
 libxdo = ctypes.CDLL("libxdo.so.3")
 
@@ -172,7 +176,7 @@ SEARCH_CLASSNAME = 1 << 6
 SEARCH_DESKTOP = 1 << 7
 
 
-SEARCH_ANY, SEARCH_ALL = xrange(2)
+SEARCH_ANY, SEARCH_ALL = range(2)
 
 
 class xdo_search_t(Structure):

--- a/xdo/xdo.py
+++ b/xdo/xdo.py
@@ -8,7 +8,7 @@ from ctypes import (Structure, POINTER, c_int, c_char, c_char_p, c_wchar,
                     c_void_p, c_long, c_uint, c_ulong, c_bool)
 
 if sys.version_info < (3,):
-        range = xrange
+    range = xrange
 
 libxdo = ctypes.CDLL("libxdo.so.3")
 


### PR DESCRIPTION
BEWARE I am not a programmer, so have a close look at this patch.
Your code is not Python 3 compatible, as "xrange(<variable>)" (Python2) now is "range(<variable>)" (Python3)  and "range(<variable>)" (Python2) now is "list(range(<variable>))" (Python 3).
I changed the code according to https://www.daniweb.com/software-development/python/threads/322517/xrange-in-python-3#post1375926 but I did not test it as I do not know how :)