### PR TITLE
bugfixes for send_keysequence_* methods

### DIFF
--- a/xdo/__init__.py
+++ b/xdo/__init__.py
@@ -264,12 +264,12 @@ class Xdo(object):
     def send_keysequence_window_up(self, window, keysequence, delay=12000):
         """Send key release (up) events for the given key sequence"""
         _libxdo.xdo_send_keysequence_window_up(
-            self._xdo, window, keysequence, delay=12000)
+            self._xdo, window, keysequence, ctypes.c_ulong(delay))
 
     def send_keysequence_window_down(self, window, keysequence, delay=12000):
         """Send key press (down) events for the given key sequence"""
         _libxdo.xdo_send_keysequence_window_down(
-            self._xdo, window, keysequence, delay=12000)
+            self._xdo, window, keysequence, ctypes.c_ulong(delay))
 
     def send_keysequence_window_list_do(
             self, window, keys, pressed=1, modifier=None, delay=120000):

--- a/xdo/xdo.py
+++ b/xdo/xdo.py
@@ -627,7 +627,7 @@ Send key release (up) events for the given key sequence.
 # int xdo_send_keysequence_window_down(const xdo_t *xdo, Window window,
 #                          const char *keysequence, useconds_t delay);
 libxdo.xdo_send_keysequence_window_down.argtypes = (
-    POINTER(xdo_t), POINTER(window_t), c_char_p, useconds_t)
+    POINTER(xdo_t), window_t, c_char_p, useconds_t)
 libxdo.xdo_send_keysequence_window_down.restype = c_int
 libxdo.xdo_send_keysequence_window_down.errcheck = _errcheck
 libxdo.xdo_send_keysequence_window_down.__doc__ = """\


### PR DESCRIPTION
A couple of fixes

bugfix: `libxdo.xdo_send_keysequence_window_down.argtypes` improperly set the window_id parameter.

bugfix: `send_keysequence_window_up` ignored delay parameter

bugfix: `send_keysequence_windown_down` ignored delay parameter 