### PR TITLE
remove reading longdesc from missing files in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,7 @@
-import os
-
 from setuptools import find_packages, setup
 
 version = '0.1.2a0'
 install_requires = ['six']
-
-here = os.path.dirname(__file__)
-
-with open(os.path.join(here, 'README.rst')) as fp:
-    longdesc = fp.read()
-
-with open(os.path.join(here, 'CHANGELOG.rst')) as fp:
-    longdesc += "\n\n" + fp.read()
 
 setup(
     name='python-libxdo',


### PR DESCRIPTION
Attempting to pip install the latest release produces the following error:

```
$ pip install python-libxdo==0.1.2a0
Collecting python-libxdo==0.1.2a0
  Using cached python-libxdo-0.1.2a0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-rdQkct/python-libxdo/setup.py", line 13, in <module>
        with open(os.path.join(here, 'CHANGELOG.rst')) as fp:
    IOError: [Errno 2] No such file or directory: '/tmp/pip-build-rdQkct/python-libxdo/CHANGELOG.rst'
```

I assume this is because sdist doesn't bundle the changelog or readme in the source tarball unless they are explicitly listed in a manifest file.

This PR removes the reading those file into `longdesc` which was not being used.